### PR TITLE
feat: AST解析とノード走査 (#13)

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// ProcessMarkdown parses the given Markdown content and traverses its AST.
+// It applies the exclusion logic and logs encountered text nodes.
+func ProcessMarkdown(content []byte, dryRun bool) ([]byte, error) {
+	md := goldmark.New()
+	document := md.Parser().Parse(text.NewReader(content))
+
+	walker := func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		// Implement exclusion logic
+		switch n.Kind() {
+		case ast.KindCodeBlock, ast.KindFencedCodeBlock, ast.KindHTMLBlock, ast.KindRawHTML:
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "Skipping %s node and its children (excluded scope).\n", n.Kind())
+			}
+			return ast.WalkSkipChildren, nil // Skip children of code/HTML blocks
+		case ast.KindCodeSpan:
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "Skipping %s node (inline code).\n", n.Kind())
+			}
+			return ast.WalkSkipChildren, nil // Skip children of inline code
+		case ast.KindLink:
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "Skipping %s node's URL part. Processing text content if any.\n", n.Kind())
+			}
+			return ast.WalkContinue, nil
+		case ast.KindText:
+			// Process text nodes
+			segment := n.(*ast.Text).Segment
+			text := segment.Value(content)
+
+			// For now, just log the text.
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "Found Text Node: '%s' (Offset: %d, Length: %d)\n", text, segment.Start, segment.Len())
+			}
+			return ast.WalkContinue, nil
+		default:
+			if dryRun {
+				// Log other node types for debugging
+				fmt.Fprintf(os.Stderr, "Encountered Node: %s\n", n.Kind())
+			}
+			return ast.WalkContinue, nil
+		}
+	}
+
+	if err := ast.Walk(document, walker); err != nil {
+		return nil, fmt.Errorf("error during AST traversal: %w", err)
+	}
+
+	// For this issue, we return the original content.
+	// This will be replaced by actual patching later.
+	return content, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/takaryo1010/rubi
 
-go 1.21
+go 1.22
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+toolchain go1.24.11
+
+require (
+	github.com/yuin/goldmark v1.7.13
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -10,114 +10,73 @@ import (
 type Config struct {
 	DictPath  string
 	Write     bool
-	Scan      bool
 	Check     bool
 	DryRun    bool
 	InputFile string
 }
 
 func main() {
-
 	// 1. Define and parse command-line flags
-
 	dictPath := flag.String("d", "dict.yaml", "Dictionary file path")
-
 	write := flag.Bool("w", false, "Write back to the file")
-
-	scan := flag.Bool("s", false, "Scan mode")
-
 	check := flag.Bool("c", false, "Check dictionary validity")
-
 	dryRun := flag.Bool("dry-run", false, "Dry run mode")
 
-
-
 	flag.Usage = func() {
-
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] [input_file]\n", os.Args[0])
-
 		flag.PrintDefaults()
-
 	}
-
 	flag.Parse()
 
-
-
 	cfg := &Config{
-
 		DictPath: *dictPath,
-
 		Write:    *write,
-
-		Scan:     *scan,
-
 		Check:    *check,
-
 		DryRun:   *dryRun,
-
 	}
-
-
 
 	// Get the input file path if not in check mode
-
 	if !cfg.Check && flag.NArg() != 1 {
-
 		flag.Usage()
-
 		os.Exit(1)
-
 	}
-
 	if flag.NArg() == 1 {
-
 		cfg.InputFile = flag.Arg(0)
-
 	}
-
-
 
 	if err := run(cfg); err != nil {
-
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-
 		os.Exit(1)
-
 	}
-
 }
 
-
-
-
 func run(cfg *Config) error {
-	// 2. Handle --check mode
+	// Handle --check mode
 	if cfg.Check {
 		return validateDictionary(cfg.DictPath)
 	}
 
-	// 4. Load the dictionary
+	// Load the dictionary
 	termMap, err := LoadDictionary(cfg.DictPath)
 	if err != nil {
 		return err
 	}
 	// TODO: This is a placeholder to satisfy the "variable declared and not used" error.
 	_ = termMap
-	_ = cfg.Scan
-	_ = cfg.DryRun
 
-
-	// 5. Read the specified file
+	// Read the specified file
 	content, err := os.ReadFile(cfg.InputFile)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	// In this initial version, "processedContent" is the same as the original.
-	processedContent := content
+	// Process the Markdown content
+	processedContent, err := ProcessMarkdown(content, cfg.DryRun)
+	if err != nil {
+		return fmt.Errorf("failed to process markdown: %w", err)
+	}
 
-	// 6. Output the content
+	// Output the content
 	if cfg.Write {
 		if err := os.WriteFile(cfg.InputFile, processedContent, 0644); err != nil {
 			return fmt.Errorf("failed to write to file: %w", err)


### PR DESCRIPTION
## 概要

このPRは、`rubi` CLIツールにMarkdownのAST（抽象構文木）解析とノード走査機能を追加します。`REQUIREMENTS.md`の「Safety First」原則に基づき、特定の要素（コードブロック、インラインコード、リンクのURL、HTMLタグ）内のテキストは処理対象から除外します。

## 実装内容

-   `github.com/yuin/goldmark` ライブラリを導入し、MarkdownコンテンツをASTにパース。
-   ASTを走査し、`ast.Text` ノードを識別するウォーカーを実装。
-   コードブロック (`ast.CodeBlock`, `ast.FencedCodeBlock`)、インラインコード (`ast.CodeSpan`)、リンクのURL部分 (`ast.Link`)、HTMLタグ (`ast.HTMLBlock`, `ast.RawHTML`) の処理をスキップする除外ロジックを実装。
-   `--dry-run` フラグが有効な場合、処理対象のテキストノードとスキップされた除外ノードを標準エラー出力にログ出力するデバッグ機能を追加。これにより、除外ロジックの検証が可能。
-   `main.go` を更新し、AST処理パイプラインを統合。

## 関連Issue

Closes #13