### PR TITLE
feat: マニュアルモードの実装 (#15)

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func run(cfg *Config) error {
 	}
 
 	// Process the Markdown content
-	processedContent, err := ProcessMarkdown(content, cfg.DryRun)
+	processedContent, err := ProcessMarkdown(content, cfg.DryRun, termMap)
 	if err != nil {
 		return fmt.Errorf("failed to process markdown: %w", err)
 	}


### PR DESCRIPTION
## 概要

このPRは、`rubi` CLIツールのマニュアルモードを実装します。Markdownドキュメント内で明示的に `:rubi` サフィックスでマークされた単語を辞書に基づいてルビ付きHTMLに変換します。また、前回のPRで指摘された`--scan`フラグの未使用問題や`ProcessMarkdown`関数の効率性に関するフィードバックにも対応しています。

## 実装内容

-   `ast.go` を修正し、`ProcessMarkdown` 関数内で `ast.Text` ノードにおける `:rubi` サフィックスを持つ単語を検出。
-   検出された単語を辞書でルックアップし、パッチ情報を生成。
-   `ApplyPatches` 関数を再導入し、生成されたパッチを元のMarkdownコンテンツに適用するメカニズムを実装（オフセットずれ防止のため逆順適用）。
-   辞書に単語が見つからない場合は警告ログを出力し、`:rubi` サフィックスを削除する処理を追加。
-   `main.go` を更新し、`ProcessMarkdown` から返されるパッチが適用されたコンテンツを使用するように統合。
-   `main.go` から未使用の `--scan` フラグおよび `Config` 構造体からの `Scan` フィールドを削除。
-   `ProcessMarkdown` 関数のシグネチャを `io.Reader` から `[]byte` に変更し、効率性を向上。

## 関連Issue

Closes #15