### PR TITLE
feat: スキャンモードの実装 (#17)

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -15,6 +15,8 @@ import (
 
 // Regex to find "word:rubi". It's a package-level variable to avoid recompilation.
 // Matches one or more word characters (alphanumeric and underscore).
+// Note: \w in Go's regex typically includes alphanumeric and underscore.
+// For Japanese characters, a different regex might be needed (e.g., Unicode categories).
 var rubiRegex = regexp.MustCompile(`(\w+):rubi\b`)
 
 // Patch represents a single change to be applied to the content.
@@ -62,13 +64,18 @@ func ApplyPatches(original []byte, patches []Patch) ([]byte, error) {
 }
 
 // ProcessMarkdown parses the given Markdown content and traverses its AST.
-// It finds words marked with the ":rubi" suffix and converts them to HTML ruby tags
-// based on the provided term dictionary.
-func ProcessMarkdown(content []byte, dryRun bool, termMap map[string]Term) ([]byte, error) {
+// In manual mode, it finds words marked with the ":rubi" suffix and converts them to HTML ruby tags.
+// In scan mode, it automatically detects all dictionary terms and converts them to HTML ruby tags.
+// The firstOnly parameter (only valid in scan mode) limits conversion to the first occurrence of each term.
+// All conversions are based on the provided term dictionary.
+func ProcessMarkdown(content []byte, dryRun bool, scan bool, firstOnly bool, termMap map[string]Term) ([]byte, error) {
 	md := goldmark.New()
 	document := md.Parser().Parse(text.NewReader(content))
 
 	var patches []Patch
+	// To track terms for firstOnly. Note: this tracking is case-sensitive based on matched word.
+	// If case-insensitivity is desired, terms should be normalized (e.g., to lowercase) before tracking.
+	processedTerms := make(map[string]bool) 
 
 	walker := func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -78,8 +85,6 @@ func ProcessMarkdown(content []byte, dryRun bool, termMap map[string]Term) ([]by
 		// Implement exclusion logic
 		switch n.Kind() {
 		case ast.KindCodeBlock, ast.KindFencedCodeBlock, ast.KindHTMLBlock, ast.KindRawHTML, ast.KindCodeSpan:
-			// No dryRun log here for now, to keep output cleaner.
-			// The primary logging for dryRun is for the patches themselves.
 			return ast.WalkSkipChildren, nil
 		case ast.KindLink:
 			return ast.WalkContinue, nil
@@ -88,35 +93,71 @@ func ProcessMarkdown(content []byte, dryRun bool, termMap map[string]Term) ([]by
 			textBytes := segment.Value(content)
 			textStr := string(textBytes)
 
-			matches := rubiRegex.FindAllStringSubmatchIndex(textStr, -1)
-			if len(matches) == 0 {
-				return ast.WalkContinue, nil
-			}
+			if scan {
+				// Scan mode: find any dictionary term
+				for termStr, termData := range termMap {
+					// Use a word boundary to prevent partial matches (e.g., "go" matching "golang")
+					// This regex finds all occurrences of the term in the text node
+					// We use a non-capturing group for the word boundary \b to avoid issues with FindAllStringSubmatchIndex
+					// Note: \w in Go's regex typically includes alphanumeric and underscore.
+					// For Japanese characters, a different regex might be needed (e.g., Unicode categories).
+					scanTermRegex := regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, regexp.QuoteMeta(termStr)))
+					matches := scanTermRegex.FindAllStringSubmatchIndex(textStr, -1)
 
-			for _, match := range matches {
-				fullMatchStart := segment.Start + match[0]
-				fullMatchEnd := segment.Start + match[1]
-				wordStart := segment.Start + match[2]
-				wordEnd := segment.Start + match[3]
-				
-				originalWordStr := string(content[wordStart:wordEnd])
+					for _, match := range matches {
+						word := textStr[match[2]:match[3]] // Extract the matched word (first capturing group)
 
-				if term, found := termMap[originalWordStr]; found {
-					// Term found in dictionary, create ruby tag, escaping HTML characters
-					safeWord := html.EscapeString(originalWordStr)
-					safeYomi := html.EscapeString(term.Yomi)
-					newText := fmt.Sprintf("<ruby>%s<rt>%s</rt></ruby>", safeWord, safeYomi)
-					patches = append(patches, Patch{Start: fullMatchStart, End: fullMatchEnd, NewText: []byte(newText)})
-					if dryRun {
-						fmt.Fprintf(os.Stderr, "GENERATING PATCH: Found '%s:rubi', replace with '%s' (Offset: %d-%d)\n", originalWordStr, newText, fullMatchStart, fullMatchEnd)
+						// Check if term already processed in firstOnly mode. Case-sensitive tracking based on matched word.
+						if firstOnly && processedTerms[word] {
+							continue
+						}
+
+						fullMatchStart := segment.Start + match[0]
+						fullMatchEnd := segment.Start + match[1]
+
+						// Term found in dictionary, create ruby tag, escaping HTML characters
+						safeWord := html.EscapeString(word)
+						safeYomi := html.EscapeString(termData.Yomi)
+						newText := fmt.Sprintf("<ruby>%s<rt>%s</rt></ruby>", safeWord, safeYomi)
+						patches = append(patches, Patch{Start: fullMatchStart, End: fullMatchEnd, NewText: []byte(newText)})
+						if dryRun {
+							fmt.Fprintf(os.Stderr, "GENERATING PATCH (Scan Mode): Found '%s', replace with '%s' (Offset: %d-%d)\n", word, newText, fullMatchStart, fullMatchEnd)
+						}
+						processedTerms[word] = true // Mark as processed
 					}
-				} else {
-					// Term not found, remove ":rubi" suffix
-					patches = append(patches, Patch{Start: wordEnd, End: fullMatchEnd, NewText: []byte("")})
-					if dryRun {
-						fmt.Fprintf(os.Stderr, "WARNING: Term '%s' not found in dictionary. The ':rubi' suffix would be removed (dry-run mode, no changes applied).\n", originalWordStr)
+				}
+			} else {
+				// Manual mode: find "word:rubi"
+				matches := rubiRegex.FindAllStringSubmatchIndex(textStr, -1)
+				if len(matches) == 0 {
+					return ast.WalkContinue, nil
+				}
+
+				for _, match := range matches {
+					fullMatchStart := segment.Start + match[0]
+					fullMatchEnd := segment.Start + match[1]
+					wordStart := segment.Start + match[2]
+					wordEnd := segment.Start + match[3]
+					
+					originalWordStr := string(content[wordStart:wordEnd])
+
+					if term, found := termMap[originalWordStr]; found {
+						// Term found in dictionary, create ruby tag, escaping HTML characters
+						safeWord := html.EscapeString(originalWordStr)
+						safeYomi := html.EscapeString(term.Yomi)
+						newText := fmt.Sprintf("<ruby>%s<rt>%s</rt></ruby>", safeWord, safeYomi)
+						patches = append(patches, Patch{Start: fullMatchStart, End: fullMatchEnd, NewText: []byte(newText)})
+						if dryRun {
+							fmt.Fprintf(os.Stderr, "GENERATING PATCH (Manual Mode): Found '%s:rubi', replace with '%s' (Offset: %d-%d)\n", originalWordStr, newText, fullMatchStart, fullMatchEnd)
+						}
 					} else {
-						fmt.Fprintf(os.Stderr, "WARNING: Term '%s' not found in dictionary. Removing ':rubi' suffix.\n", originalWordStr)
+						// Term not found, remove ":rubi" suffix
+						patches = append(patches, Patch{Start: wordEnd, End: fullMatchEnd, NewText: []byte("")})
+						if dryRun {
+							fmt.Fprintf(os.Stderr, "WARNING (Manual Mode): Term '%s' not found in dictionary. The ':rubi' suffix would be removed (dry-run mode, no changes applied).\n", originalWordStr)
+						} else {
+							fmt.Fprintf(os.Stderr, "WARNING (Manual Mode): Term '%s' not found in dictionary. Removing ':rubi' suffix.\n", originalWordStr)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## 概要

このPRは、`rubi` CLIツールにおけるスキャンモードを実装します。このモードでは、Markdownドキュメント全体を走査し、辞書に存在する単語を自動的に検出してHTMLのルビタグ（`<ruby>`）を付与します。また、「初出のみ変換」オプションもサポートします。

## 実装内容

-   `main.go` の `Config` 構造体およびコマンドライン引数に `scan` ( `-s` ) と `firstOnly` ( `--first-only` ) フラグを再導入。
-   `main.go` に、これらのフラグの正しい使用法を検証するロジック（排他的な利用など）を追加。
-   `ast.go` の `ProcessMarkdown` 関数を修正し、`scan` モードが有効な場合の処理ロジックを実装。
    -   `ast.Text` ノードを走査し、辞書 (`termMap`) に存在する単語を検出。
    -   `firstOnly` フラグが `true` の場合、一度ルビを付与した単語はそれ以降の検出では無視するように、既出単語を追跡するメカニズムを実装。
    -   `scan` が `false` の場合は、既存のマニュアルモードロジック（`:rubi` サフィックス検出）が動作するように切り分け。

## 関連Issue

Closes #17
