### PR TITLE
feat: Community Dictionary Features (rubi init, rubi dict update) (#21)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 // Config holds the application configuration
@@ -17,68 +20,126 @@ type Config struct {
 	InputFile string
 }
 
+// Global flags for the main command
+var (
+	mainFlagSet = flag.NewFlagSet("rubi", flag.ExitOnError)
+	dictPath    = mainFlagSet.String("d", "dict.yaml", "Dictionary file path")
+	write       = mainFlagSet.Bool("w", false, "Write back to the file")
+	scan        = mainFlagSet.Bool("s", false, "Scan mode")
+	firstOnly   = mainFlagSet.Bool("first-only", false, "Convert only the first occurrence of each term in scan mode")
+	check       = mainFlagSet.Bool("c", false, "Check dictionary validity")
+	dryRun      = mainFlagSet.Bool("dry-run", false, "Dry run mode")
+)
+
+// cmdRunner is a package-level variable that can be overridden for testing.
+var cmdRunner = exec.Command
+
+// Subcommand flag sets
+var (
+	initFlagSet   = flag.NewFlagSet("init", flag.ExitOnError)
+	initRepo      = initFlagSet.String("repo", "takaryo1010/rubi", "GitHub repository to download dict.yaml from (e.g., owner/repo)")
+	initOverwrite = initFlagSet.Bool("overwrite", false, "Overwrite existing dict.yaml if it exists")
+
+	dictUpdateFlagSet = flag.NewFlagSet("dict update", flag.ExitOnError) // FlagSet for 'dict update'
+	dictUpdateRepo    = dictUpdateFlagSet.String("repo", "takaryo1010/rubi", "GitHub repository to download dict.yaml from (e.g., owner/repo)")
+)
+
 func main() {
-	// 1. Define and parse command-line flags
-	dictPath := flag.String("d", "dict.yaml", "Dictionary file path")
-	write := flag.Bool("w", false, "Write back to the file")
-	scan := flag.Bool("s", false, "Scan mode") // Reintroduced scan flag definition
-	firstOnly := flag.Bool("first-only", false, "Convert only the first occurrence of each term in scan mode") // New first-only flag definition
-	check := flag.Bool("c", false, "Check dictionary validity")
-	dryRun := flag.Bool("dry-run", false, "Dry run mode")
-
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] [input_file]\n", os.Args[0])
-		flag.PrintDefaults()
-	}
-	flag.Parse()
-
-	cfg := &Config{
-		DictPath:  *dictPath,
-		Write:     *write,
-		Scan:      *scan,      // Assign scan flag
-		FirstOnly: *firstOnly, // Assign first-only flag
-		Check:     *check,
-		DryRun:    *dryRun,
-	}
-
-	// Logic for flag validation
-	if cfg.Check {
-		if flag.NArg() > 0 {
-			flag.Usage()
-			os.Exit(1)
-		}
-		if cfg.Scan || cfg.FirstOnly || cfg.Write || cfg.DryRun {
-			fmt.Fprintln(os.Stderr, "Error: -c flag cannot be used with other processing flags (-s, --first-only, -w, --dry-run)")
-			os.Exit(1)
-		}
-	} else if cfg.Scan { // Scan mode validation
-		if flag.NArg() != 1 {
-			flag.Usage()
-			os.Exit(1)
-		}
-		// No specific additional checks for scan mode yet, just input file presence
-	} else { // Manual mode validation
-		if cfg.FirstOnly {
-			fmt.Fprintln(os.Stderr, "Error: --first-only flag is only valid in -s (scan) mode")
-			os.Exit(1)
-		}
-		if flag.NArg() != 1 {
-			flag.Usage()
-			os.Exit(1)
-		}
-	}
-	
-	if flag.NArg() == 1 {
-		cfg.InputFile = flag.Arg(0)
-	}
-
-	if err := run(cfg); err != nil {
+	if err := runCLI(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(cfg *Config) error {
+func runCLI() error {
+	// Custom usage function for the main command
+	mainFlagSet.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s [options] <input_file>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s <command> [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Commands:\n")
+		fmt.Fprintf(os.Stderr, "  init        Initialize a dict.yaml from GitHub\n")
+		fmt.Fprintf(os.Stderr, "  dict update Update dict.yaml from GitHub\n") // Updated usage
+		fmt.Fprintf(os.Stderr, "Options for main command:\n")
+		mainFlagSet.PrintDefaults()
+	}
+
+	// If no arguments or first arg is a flag, parse main flags
+	if len(os.Args) < 2 || strings.HasPrefix(os.Args[1], "-") {
+		mainFlagSet.Parse(os.Args[1:])
+		cfg := &Config{
+			DictPath:  *dictPath,
+			Write:     *write,
+			Scan:      *scan,
+			FirstOnly: *firstOnly,
+			Check:     *check,
+			DryRun:    *dryRun,
+		}
+		if mainFlagSet.NArg() > 0 {
+			cfg.InputFile = mainFlagSet.Arg(0)
+		}
+		return handleMainCommand(cfg)
+	}
+
+	// Otherwise, parse subcommands
+	switch os.Args[1] {
+	case "init":
+		initFlagSet.Usage = func() {
+			fmt.Fprintf(os.Stderr, "Usage of %s init:\n", os.Args[0])
+			fmt.Fprintf(os.Stderr, "  %s init [options]\n", os.Args[0])
+			initFlagSet.PrintDefaults()
+		}
+		initFlagSet.Parse(os.Args[2:])
+		return handleInitCommand(*initRepo, *initOverwrite)
+	case "dict": // New subcommand 'dict'
+		if len(os.Args) < 3 {
+			return fmt.Errorf("missing subcommand for 'dict'\n\nUsage: %s dict <command> [options]\nCommands:\n  update", os.Args[0])
+		}
+		switch os.Args[2] {
+		case "update":
+			dictUpdateFlagSet.Usage = func() {
+				fmt.Fprintf(os.Stderr, "Usage of %s dict update:\n", os.Args[0])
+				fmt.Fprintf(os.Stderr, "  %s dict update [options]\n", os.Args[0])
+				dictUpdateFlagSet.PrintDefaults()
+			}
+			dictUpdateFlagSet.Parse(os.Args[3:])
+			return handleUpdateCommand(*dictUpdateRepo)
+		default:
+			return fmt.Errorf("unknown subcommand for 'dict': %s\n\nUsage: %s dict <command> [options]\nCommands:\n  update", os.Args[2], os.Args[0])
+		}
+	case "help":
+		mainFlagSet.Usage()
+		return nil
+	default:
+		return fmt.Errorf("unknown command: %s", os.Args[1]) // Removed extra newlines
+	}
+}
+
+func handleMainCommand(cfg *Config) error {
+	// Logic for flag validation (from previous iteration)
+	if cfg.Check {
+		if cfg.InputFile != "" {
+			mainFlagSet.Usage()
+			return fmt.Errorf("the -c flag cannot be used with an input file")
+		}
+		if cfg.Scan || cfg.FirstOnly || cfg.Write || cfg.DryRun {
+			return fmt.Errorf("the -c flag cannot be used with other processing flags (-s, --first-only, -w, --dry-run)")
+		}
+	} else if cfg.Scan { // Scan mode validation
+		if cfg.InputFile == "" {
+			mainFlagSet.Usage()
+			return fmt.Errorf("an input file is required for scan mode (-s)")
+		}
+	} else { // Manual mode validation
+		if cfg.FirstOnly {
+			return fmt.Errorf("the --first-only flag is only valid in -s (scan) mode")
+		}
+		if cfg.InputFile == "" {
+			mainFlagSet.Usage()
+			return fmt.Errorf("an input file is required for manual mode")
+		}
+	}
+
 	// Handle --check mode
 	if cfg.Check {
 		return validateDictionary(cfg.DictPath)
@@ -90,11 +151,10 @@ func run(cfg *Config) error {
 		return err
 	}
 
-
 	// Read the specified file
 	content, err := os.ReadFile(cfg.InputFile)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to read file '%s': %w", cfg.InputFile, err)
 	}
 
 	// Process the Markdown content
@@ -106,13 +166,68 @@ func run(cfg *Config) error {
 	// Output the content
 	if cfg.Write {
 		if err := os.WriteFile(cfg.InputFile, processedContent, 0644); err != nil {
-			return fmt.Errorf("failed to write to file: %w", err)
+			return fmt.Errorf("failed to write to file '%s': %w", cfg.InputFile, err)
 		}
 		fmt.Printf("File '%s' has been updated.\n", cfg.InputFile)
 	} else {
 		fmt.Print(string(processedContent))
 	}
 
+	return nil
+}
+
+func handleInitCommand(repo string, overwrite bool) error {
+	fmt.Printf("Initializing dict.yaml from %s...\n", repo)
+	filePath := "dict.yaml"
+
+	if _, err := os.Stat(filePath); err == nil {
+		if !overwrite {
+			return fmt.Errorf("dict.yaml already exists. Use --overwrite to replace it.")
+		}
+	}
+
+	return downloadDictFile(repo, filePath)
+}
+
+func handleUpdateCommand(repo string) error {
+	fmt.Printf("Updating dict.yaml from %s...\n", repo)
+	filePath := "dict.yaml"
+	return downloadDictFile(repo, filePath)
+}
+
+func downloadDictFile(repo, filePath string) error {
+	// Construct the GitHub API URL for the raw file content
+	// Assuming dict.yaml is at the root of the main branch
+	ownerRepo := strings.Split(repo, "/")
+	if len(ownerRepo) != 2 {
+		return fmt.Errorf("invalid repository format: %s. Expected owner/repo", repo)
+	}
+	owner := ownerRepo[0]
+	repoName := ownerRepo[1]
+	
+	// Use gh api to fetch the raw content
+	// gh api -H "Accept: application/vnd.github.v3.raw" /repos/{owner}/{repo}/contents/dict.yaml
+	cmd := cmdRunner("gh", "api", "-H", "Accept: application/vnd.github.v3.raw", fmt.Sprintf("/repos/%s/%s/contents/dict.yaml", owner, repoName))
+	
+	// Capture stdout
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Include gh cli stderr in the returned error for better debugging
+		if stderr.Len() > 0 {
+			return fmt.Errorf("failed to download dict.yaml from %s (gh api stderr: %s): %w", repo, strings.TrimSpace(stderr.String()), err)
+		}
+		return fmt.Errorf("failed to download dict.yaml from %s: %w", repo, err)
+	}
+
+	// Write the content to file
+	if err := os.WriteFile(filePath, stdout.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write dict.yaml: %w", err)
+	}
+
+	fmt.Printf("Successfully downloaded dict.yaml to %s.\n", filePath)
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// originalCmdRunner stores the original exec.Command function.
+// It is intended to be used only by this test file to capture the real exec.Command.
+// The actual mocking of 'cmdRunner' (defined in main.go) will happen per test.
+var originalCmdRunner = exec.Command
+
+func TestMain(m *testing.M) {
+	// Run all tests
+	code := m.Run()
+
+	os.Exit(code)
+}
+
+// Helper to check if a file exists
+func fileExists(t *testing.T, path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+// --- Test handleInitCommand ---
+
+func TestHandleInitCommand(t *testing.T) {
+	repo := "owner/repo"
+	testContent := "test: 123"
+
+	// Create a temporary directory for the test
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Mock cmdRunner for this test
+	oldCmdRunner := cmdRunner // Save original
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		if name == "gh" && arg[0] == "api" && strings.Contains(arg[len(arg)-1], "dict.yaml") {
+			cmd := exec.Command("echo", testContent)
+			return cmd
+		}
+		return originalCmdRunner(name, arg...) // Fallback to original for other commands
+	}
+	defer func() { cmdRunner = oldCmdRunner }() // Restore original cmdRunner after test
+
+	tests := []struct {
+		name        string
+		overwrite   bool
+		preExisting bool
+		wantErr     bool
+		errContains string
+		wantFile    bool
+	}{
+		{
+			name:        "successfully initialize new file",
+			overwrite:   false,
+			preExisting: false,
+			wantErr:     false,
+			wantFile:    true,
+		},
+		{
+			name:        "file already exists, no overwrite",
+			overwrite:   false,
+			preExisting: true,
+			wantErr:     true,
+			errContains: "dict.yaml already exists",
+			wantFile:    true, // file should still exist
+		},
+		{
+			name:        "file already exists, with overwrite",
+			overwrite:   true,
+			preExisting: true,
+			wantErr:     false,
+			wantFile:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, "dict.yaml")
+			if tt.preExisting {
+				os.WriteFile(filePath, []byte("old content"), 0644)
+			} else {
+				os.Remove(filePath) // Ensure it doesn't exist
+			}
+
+			err := handleInitCommand(repo, tt.overwrite)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleInitCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("handleInitCommand() error message = %q, want error message containing %q", err.Error(), tt.errContains)
+			}
+			if tt.wantFile != fileExists(t, filePath) {
+				t.Errorf("handleInitCommand() fileExists = %v, wantFile %v", fileExists(t, filePath), tt.wantFile)
+			}
+			if tt.wantFile && !tt.wantErr { // Check content only if file exists and no error
+				content, _ := os.ReadFile(filePath)
+				if strings.TrimSuffix(string(content), "\n") != testContent { // Trim newline from echo output
+					t.Errorf("handleInitCommand() file content = %q, want %q", strings.TrimSuffix(string(content), "\n"), testContent)
+				}
+			}
+		})
+	}
+}
+
+// --- Test handleUpdateCommand ---
+
+func TestHandleUpdateCommand(t *testing.T) {
+	repo := "owner/repo"
+	testContent := "updated: 456"
+
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Mock cmdRunner for this test suite
+	oldCmdRunner := cmdRunner
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		if name == "gh" && arg[0] == "api" && strings.Contains(arg[len(arg)-1], "dict.yaml") {
+			cmd := exec.Command("echo", testContent)
+			return cmd
+		}
+		return originalCmdRunner(name, arg...)
+	}
+	defer func() { cmdRunner = oldCmdRunner }() // Restore original cmdRunner after test suite
+
+	tests := []struct {
+		name        string
+		preExisting bool
+		wantErr     bool
+		errContains string
+		wantFile    bool
+	}{
+		{
+			name:        "successfully update existing file",
+			preExisting: true,
+			wantErr:     false,
+			wantFile:    true,
+		},
+		{
+			name:        "successfully update non-existing file",
+			preExisting: false,
+			wantErr:     false,
+			wantFile:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tmpDir, "dict.yaml")
+			if tt.preExisting {
+				os.WriteFile(filePath, []byte("old content"), 0644)
+			} else {
+				os.Remove(filePath)
+			}
+
+			err := handleUpdateCommand(repo)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleUpdateCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("handleUpdateCommand() error message = %q, want error message containing %q", err.Error(), tt.errContains)
+			}
+			if tt.wantFile != fileExists(t, filePath) {
+				t.Errorf("handleUpdateCommand() fileExists = %v, wantFile %v", fileExists(t, filePath), tt.wantFile)
+			}
+			if tt.wantFile && !tt.wantErr {
+				content, _ := os.ReadFile(filePath)
+				if strings.TrimSuffix(string(content), "\n") != testContent {
+					t.Errorf("handleUpdateCommand() file content = %q, want %q", strings.TrimSuffix(string(content), "\n"), testContent)
+				}
+			}
+		})
+	}
+}
+
+// --- Test downloadDictFile ---
+
+func TestDownloadDictFile(t *testing.T) {
+	repo := "owner/repo"
+	filePath := "test_dict.yaml"
+	testContent := "downloaded: true"
+
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Mock cmdRunner for this test
+	oldCmdRunner := cmdRunner
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		if name == "gh" {
+			c := exec.Command("echo", testContent)
+			return c
+		}
+		return originalCmdRunner(name, arg...)
+	}
+	defer func() { cmdRunner = oldCmdRunner }()
+
+	err = downloadDictFile(repo, filePath)
+	if err != nil {
+		t.Fatalf("downloadDictFile() unexpectedly returned an error: %v", err)
+	}
+
+	if !fileExists(t, filePath) {
+		t.Errorf("downloadDictFile() failed to create file")
+	}
+
+	content, _ := os.ReadFile(filePath)
+	if strings.TrimSuffix(string(content), "\n") != testContent {
+		t.Errorf("downloadDictFile() file content = %q, want %q", strings.TrimSuffix(string(content), "\n"), testContent)
+	}
+}
+
+func TestDownloadDictFile_InvalidRepo(t *testing.T) {
+	repo := "invalid-repo-format"
+	filePath := "test_dict.yaml"
+
+	// Mock cmdRunner for this test
+	oldCmdRunner := cmdRunner
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		t.Fatalf("gh command should not be called for invalid repo format")
+		return nil
+	}
+	defer func() { cmdRunner = oldCmdRunner }()
+
+	err := downloadDictFile(repo, filePath)
+	if err == nil {
+		t.Errorf("downloadDictFile() expected an error for invalid repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid repository format") {
+		t.Errorf("downloadDictFile() error message = %q, want error message containing \"invalid repository format\"", err.Error())
+	}
+}
+
+func TestDownloadDictFile_GhApiError(t *testing.T) {
+	repo := "owner/repo"
+	filePath := "test_dict.yaml"
+
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Mock cmdRunner to simulate a gh api error
+	oldCmdRunner := cmdRunner
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		if name == "gh" {
+			c := exec.Command("bash", "-c", "echo 'gh api error' >&2; exit 1")
+			return c
+		}
+		return originalCmdRunner(name, arg...)
+	}
+	defer func() { cmdRunner = oldCmdRunner }()
+
+	err = downloadDictFile(repo, filePath)
+	if err == nil {
+		t.Errorf("downloadDictFile() expected an error for gh api failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to download dict.yaml from owner/repo (gh api stderr: gh api error): exit status 1") {
+		t.Errorf("downloadDictFile() error message = %q, want error message containing \"failed to download dict.yaml from owner/repo (gh api stderr: gh api error): exit status 1\"", err.Error())
+	}
+}
+
+func TestDownloadDictFile_WriteFileError(t *testing.T) {
+	repo := "owner/repo"
+	filePath := "nonexistent_dir/test_dict.yaml" // Path that will cause a write error
+	testContent := "downloaded: true"
+
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Mock cmdRunner to return predefined content
+	oldCmdRunner := cmdRunner
+	cmdRunner = func(name string, arg ...string) *exec.Cmd {
+		if name == "gh" {
+			c := exec.Command("echo", testContent)
+			return c
+		}
+		return originalCmdRunner(name, arg...)
+	}
+	defer func() { cmdRunner = oldCmdRunner }()
+
+	err = downloadDictFile(repo, filePath)
+	if err == nil {
+		t.Errorf("downloadDictFile() expected an error for write file failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to write dict.yaml") {
+		t.Errorf("downloadDictFile() error message = %q, want error message containing \"failed to write dict.yaml\"", err.Error())
+	}
+}


### PR DESCRIPTION
## 概要

このPRは、`rubi` CLIツールにおけるコミュニティ駆動型辞書の運用をサポートするための機能（`rubi init` と `rubi dict update`）を実装します。これにより、ユーザーはGitHubリポジトリから最新の辞書を容易に取得・更新できるようになります。

## 実装内容

-   **`main.go`:**
    -   `main` 関数をリファクタリングし、サブコマンド（`init`, `dict update`）を処理するように変更しました。
    -   `handleInitCommand` を実装し、GitHubから `dict.yaml` をダウンロードしてローカルに保存する機能（`--overwrite` オプション付き）を提供します。
    -   `handleUpdateCommand` を実装し、GitHubから最新の `dict.yaml` をダウンロードしてローカルファイルを更新する機能を提供します。
    -   GitHub APIとの連携には `gh api` コマンドを `os/exec` 経由で利用します。
    -   `downloadDictFile` 関数を強化し、`gh api` コマンドのエラー出力（stderr）をキャプチャし、より詳細なエラーメッセージとして返すように改善しました。
    -   未使用のインポートや `_ = termMap` プレースホルダーを削除しました。
    -   サブコマンドに対応したフラグ検証ロジックを修正しました。
-   **`main_test.go`:**
    -   `handleInitCommand`, `handleUpdateCommand`, `downloadDictFile` のための包括的なユニットテストを追加しました。
    -   `os/exec.Command` のモックには、パッケージレベルの `cmdRunner` 変数を使用する堅牢な戦略を導入し、テスト中の外部コマンド実行を制御できるようにしました。
    -   `echo` コマンドの末尾の改行や、`downloadDictFile` から返される詳細なエラーメッセージに対応するため、テストの期待値を修正しました。

## 関連Issue

Closes #21