### PR TITLE
docs: Update Vite reference in dict.yaml as example contribution

### DIFF
--- a/dict.yaml
+++ b/dict.yaml
@@ -1,7 +1,7 @@
 terms:
   - term: "Vite"
     yomi: "ヴィート"
-    ref: "[https://ja.vitejs.dev/](https://ja.vitejs.dev/)"
+    ref: "[https://ja.vitejs.dev/guide/](https://ja.vitejs.dev/guide/)"
 
   - term: "gRPC"
     yomi: "ジーアールピーシー"


### PR DESCRIPTION
Updates the 'Vite' entry in dict.yaml to include a more specific reference URL (https://ja.vitejs.dev/guide/), demonstrating a typical dictionary contribution.