### PR TITLE
fix: go fmtによるフォーマット適用

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -75,7 +75,7 @@ func ProcessMarkdown(content []byte, dryRun bool, scan bool, firstOnly bool, ter
 	var patches []Patch
 	// To track terms for firstOnly. Note: this tracking is case-sensitive based on matched word.
 	// If case-insensitivity is desired, terms should be normalized (e.g., to lowercase) before tracking.
-	processedTerms := make(map[string]bool) 
+	processedTerms := make(map[string]bool)
 
 	walker := func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -138,7 +138,7 @@ func ProcessMarkdown(content []byte, dryRun bool, scan bool, firstOnly bool, ter
 					fullMatchEnd := segment.Start + match[1]
 					wordStart := segment.Start + match[2]
 					wordEnd := segment.Start + match[3]
-					
+
 					originalWordStr := string(content[wordStart:wordEnd])
 
 					if term, found := termMap[originalWordStr]; found {

--- a/ast_test.go
+++ b/ast_test.go
@@ -12,9 +12,9 @@ import (
 // Helper function to create a simplified termMap for testing
 func createTestTermMap() map[string]Term {
 	return map[string]Term{
-		"Vite": {"Vite", "ヴィート", "https://ja.vitejs.dev/"},
-		"gRPC": {"gRPC", "ジーアールピーシー", "https://grpc.io/"},
-		"Go":   {"Go", "ゴー", ""},
+		"Vite":   {"Vite", "ヴィート", "https://ja.vitejs.dev/"},
+		"gRPC":   {"gRPC", "ジーアールピーシー", "https://grpc.io/"},
+		"Go":     {"Go", "ゴー", ""},
 		"golang": {"golang", "ゴーラング", ""},
 	}
 }
@@ -31,12 +31,12 @@ func TestApplyPatches(t *testing.T) {
 	testTermMap := createTestTermMap()
 
 	tests := []struct {
-		name          string
-		original      []byte
-		patches       []Patch
-		want          []byte
-		wantErr       bool
-		errContains   string
+		name        string
+		original    []byte
+		patches     []Patch
+		want        []byte
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name:     "no patches",
@@ -142,14 +142,14 @@ func TestProcessMarkdown_ManualMode(t *testing.T) {
 	testTermMap := createTestTermMap()
 
 	tests := []struct {
-		name         string
-		input        string
-		dryRun       bool
-		scan         bool
-		firstOnly    bool
-		wantOutput   string
-		wantLogs     []string // Expected substrings in stderr output
-		wantErr      bool
+		name       string
+		input      string
+		dryRun     bool
+		scan       bool
+		firstOnly  bool
+		wantOutput string
+		wantLogs   []string // Expected substrings in stderr output
+		wantErr    bool
 	}{
 		{
 			name:       "basic manual conversion",
@@ -236,7 +236,7 @@ func TestProcessMarkdown_ManualMode(t *testing.T) {
 
 			w.Close()
 			os.Stderr = oldStderr // Restore stderr
-			
+
 			// Read captured stderr
 			stderrBytes, _ := io.ReadAll(r)
 			stderrOutput := string(stderrBytes)
@@ -273,14 +273,14 @@ func TestProcessMarkdown_ScanMode(t *testing.T) {
 	testTermMap := createTestTermMap()
 
 	tests := []struct {
-		name         string
-		input        string
-		dryRun       bool
-		scan         bool
-		firstOnly    bool
-		wantOutput   string
-		wantLogs     []string
-		wantErr      bool
+		name       string
+		input      string
+		dryRun     bool
+		scan       bool
+		firstOnly  bool
+		wantOutput string
+		wantLogs   []string
+		wantErr    bool
 	}{
 		{
 			name:       "basic scan conversion",
@@ -376,7 +376,7 @@ func TestProcessMarkdown_ScanMode(t *testing.T) {
 
 			w.Close()
 			os.Stderr = oldStderr // Restore stderr
-			
+
 			// Read captured stderr
 			stderrBytes, _ := io.ReadAll(r)
 			stderrOutput := string(stderrBytes)

--- a/main.go
+++ b/main.go
@@ -221,11 +221,11 @@ func downloadDictFile(repo, filePath string) error {
 	}
 	owner := ownerRepo[0]
 	repoName := ownerRepo[1]
-	
+
 	// Use gh api to fetch the raw content
 	// gh api -H "Accept: application/vnd.github.v3.raw" /repos/{owner}/{repo}/contents/dict.yaml
 	cmd := cmdRunner("gh", "api", "-H", "Accept: application/vnd.github.v3.raw", fmt.Sprintf("/repos/%s/%s/contents/dict.yaml", owner, repoName))
-	
+
 	// Capture stdout
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
## 概要

このPRは、`rubi` プロジェクト内のGo言語ファイル（`ast.go`, `ast_test.go`, `main.go`）に標準的な`go fmt`フォーマットを適用します。これにより、コードの可読性と一貫性が向上し、Goのコーディング規約に準拠します。

## 主な変更点

-   `ast.go`: `go fmt`によるフォーマット適用
-   `ast_test.go`: `go fmt`によるフォーマット適用
-   `main.go`: `go fmt`によるフォーマット適用

## 関連Issue

なし